### PR TITLE
Ensure that `body_html` is set to html

### DIFF
--- a/scrapers/berniesanders.com/news.py
+++ b/scrapers/berniesanders.com/news.py
@@ -87,7 +87,7 @@ class ArticlesScraper(Scraper):
                     rec["body"], rec["body_html"] = text, text
                     rec['article_type'] = "ExternalLink"
                 elif text and html:
-                    rec["body"], rec["body_html"] = text, text
+                    rec["body"], rec["body_html"] = text, html
                     try:
                         article["image_url"]
                     except KeyError:


### PR DESCRIPTION
Please excuse me if I've misread the code, but I noticed that I'm seeing plain text content in some of the body_html values for news items (for instance, news item with `_id` of 56203e66aa9534000134131c - https://berniesanders.com/press-release/big-numbers-of-small-donors-fill-sanders-campaign-coffers/). I *think* this should fix it - let me know if I'm doing it wrong :)