### PR TITLE
Include event_type_name in events

### DIFF
--- a/scrapers/berniesanders.com/events.py
+++ b/scrapers/berniesanders.com/events.py
@@ -30,7 +30,8 @@ allowed_keys = [
     "attendee_count",
     "capacity",
     "site",
-    "lang"
+    "lang",
+    "event_type_name"
 ]
 
 logging.basicConfig(format="%(asctime)s - %(levelname)s : %(message)s",


### PR DESCRIPTION
It'd be nice to be able to filter by event type name in the iOS app, and I feel like this is generic enough metadata that other folk can make use of it :sunglasses: 