### PR TITLE
Simple scraper tweaks

### DIFF
--- a/scrapers/berniesanders.com/articles.py
+++ b/scrapers/berniesanders.com/articles.py
@@ -60,8 +60,8 @@ class ArticlesScraper(Scraper):
                 "excerpt": self.html.unescape(
                     article.find(
                         "div", {"class": "excerpt"}).p.text),
-                "title": article.h2.text,
-                "article_category": article.h1.string.strip(),
+                "title": self.html.unescape(article.h2.text),
+                "article_category": self.html.unescape(article.h1.string.strip()),
                 "url": article.h2.a["href"]
             }
             if article.img is not None:

--- a/scrapers/berniesanders.com/news.py
+++ b/scrapers/berniesanders.com/news.py
@@ -53,8 +53,8 @@ class ArticlesScraper(Scraper):
                 "created_at": parser.parse(article.time["datetime"]),
                 "site": "berniesanders.com",
                 "lang": "en",
-                "title": article.h2.text,
-                "article_category": article.h1.string.strip(),
+                "title": self.html.unescape(article.h2.text),
+                "article_category": self.html.unescape(article.h1.string.strip()),
                 "url": article.h2.a["href"]
             }
 

--- a/scrapers/scraper.py
+++ b/scrapers/scraper.py
@@ -22,8 +22,7 @@ class Scraper(object):
 
     def sanitize_soup(self, soup):
         # inspired by https://chase-seibert.github.io/blog/2011/01/28/sanitize-html-with-beautiful-soup.html  
-
-        blacklist = ["script", "noscript", "video"]
+        blacklist = ["script", "noscript", "video", "style"]
 
         for tag in soup.findAll():
             if tag.name.lower() in blacklist:
@@ -39,7 +38,7 @@ class Scraper(object):
         text = ''
         for elem in element.recursiveChildGenerator():
             if isinstance(elem, types.StringTypes):
-                text += elem.strip()
+                text += elem.rstrip("\n")
             elif elem.name == 'br':
                 text += '\n'
         return text

--- a/scrapers/scraper.py
+++ b/scrapers/scraper.py
@@ -22,7 +22,7 @@ class Scraper(object):
 
     def sanitize_soup(self, soup):
         # inspired by https://chase-seibert.github.io/blog/2011/01/28/sanitize-html-with-beautiful-soup.html  
-        blacklist = ["script", "noscript", "video", "style"]
+        blacklist = ["script", "noscript", "video"]
 
         for tag in soup.findAll():
             if tag.name.lower() in blacklist:


### PR DESCRIPTION
- ensure we unescape article/news item titles
- `rstrip` newlines rather than `strip` whitespace (this should fix text
  in inline links being effectively concatenated with non-link text)
- sanitize inline style tags - these mess up plain text content